### PR TITLE
Add coverage reporting to our automated build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: cpp
 compiler: clang
 
+before_install:
+  - pip install --user cpp-coveralls
+
 before_script:
   - mkdir build
   - cd build
@@ -9,3 +12,6 @@ before_script:
 script:
   - cmake --build .
   - ctest .
+
+after_success:
+  - coveralls --exclude build/CMakeFiles/ --gcov "llvm-cov gcov" --gcov-options '\-lp'  -r ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(SudokuSolver)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+
 add_subdirectory(lib)
 add_subdirectory(app)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Sudoku-Solver
 
 [![Build Status](https://travis-ci.org/ob-algdatii-ss18/leistungsnachweis-mamatofe.svg?branch=master)](https://travis-ci.org/ob-algdatii-ss18/leistungsnachweis-mamatofe)
+[![Coverage Status](https://coveralls.io/repos/github/ob-algdatii-ss18/leistungsnachweis-mamatofe/badge.svg?branch=master)](https://coveralls.io/github/ob-algdatii-ss18/leistungsnachweis-mamatofe?branch=master)
 
 ## Build instructions
 
@@ -13,3 +14,5 @@ cmake ..
 cmake --build .
 ctest .
 ```
+
+If you only want to run the application, you will find the binary under `build/app/sudoku-solver`.


### PR DESCRIPTION
This pull request integrates automatic coverage reporting to coveralls. The coverage is always measured but only the build on Travis does the export to coveralls.

This closes #6 