### PR TITLE
Generate and deploy documentation with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,40 @@
 language: cpp
 compiler: clang
 
+addons:
+  apt:
+    packages:
+      - doxygen
+      - graphviz
+      - python-sphinx
+
 before_install:
   - pip install --user cpp-coveralls
+  - pip install --user breathe
 
 before_script:
   - mkdir build
   - cd build
   - cmake ..
+  - cd ..
 
 script:
+  - cd build
   - cmake --build .
   - ctest .
+  - cd ..
+  - cd doc
+  - doxygen
+  - make html
+  - cd ..
 
 after_success:
   - coveralls --exclude build/CMakeFiles/ --gcov "llvm-cov gcov" --gcov-options '\-lp'  -r ..
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  local-dir: doc/_build/html
+  on:
+    branch: master

--- a/README.md
+++ b/README.md
@@ -16,3 +16,14 @@ ctest .
 ```
 
 If you only want to run the application, you will find the binary under `build/app/sudoku-solver`.
+
+## Documentation
+
+Doxygen, Sphinx and breathe need to be installed to generate the documentation.
+You have to run these commands: 
+
+```sh
+cd doc
+doxygen
+make html
+``` 


### PR DESCRIPTION
We do now generate the documentation automatically with each build on
travis. If the commit is on the master branch we do also deploy the
website to github pages.

Closes #10 