### PR TITLE
Fix submission of coverage to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - cd ..
 
 after_success:
-  - coveralls --exclude build/CMakeFiles/ --gcov "llvm-cov gcov" --gcov-options '\-lp'  -r ..
+  - coveralls --exclude build/CMakeFiles/ --gcov "llvm-cov gcov" --gcov-options '\-lp'
 
 deploy:
   provider: pages


### PR DESCRIPTION
Due to the changes to our travis configuration, the submission of the
measured coverage to coveralls had a little error as it is not executed
in a subdirectory but from the project root. Therefor we do not need to
change the directory for the coveralls call.