### PR TITLE
Enable cppcheck in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - cd ..
 
 script:
-  - cppcheck --enable=warning,style,performance,portability,unusedFunction --verbose -I lib/include app/ lib/
+  - cppcheck --error-exitcode=1 --enable=warning,style,performance,portability,unusedFunction --verbose -I lib/include app/ lib/
   - cd build
   - cmake --build .
   - ctest .

--- a/lib/include/suso.h
+++ b/lib/include/suso.h
@@ -12,14 +12,23 @@ class Sudoku {
 private:
     std::array<std::array<int, 9>, 9> field;
 public:
-    Sudoku();
+    Sudoku() : field({{{5, 3, 0, 0, 7, 0, 0, 0, 0},
+                              {6, 0, 0, 1, 9, 5, 0, 0, 0},
+                              {0, 9, 8, 0, 0, 0, 0, 6, 0},
+                              {8, 0, 0, 0, 6, 0, 0, 0, 3},
+                              {4, 0, 0, 8, 0, 3, 0, 0, 1},
+                              {7, 0, 0, 0, 2, 0, 0, 0, 6},
+                              {0, 6, 0, 0, 0, 0, 2, 8, 0},
+                              {0, 0, 0, 4, 1, 9, 0, 0, 5},
+                              {0, 0, 0, 0, 8, 0, 0, 7, 9}}}) {};
 
     std::vector<int> validNumbers(position pos);
 
     bool solveNakedSingles();
+
     bool solveHiddenSngles();
 
-    friend std::ostream& operator<< (std::ostream& stream, const Sudoku& sudoku);
+    friend std::ostream &operator<<(std::ostream &stream, const Sudoku &sudoku);
 };
 
 #endif // __SUSO_H__

--- a/lib/src/suso.cpp
+++ b/lib/src/suso.cpp
@@ -2,21 +2,9 @@
 
 #include "suso.h"
 
-Sudoku::Sudoku() {
-    field = {{{5, 3, 0, 0, 7, 0, 0, 0, 0},
-                     {6, 0, 0, 1, 9, 5, 0, 0, 0},
-                     {0, 9, 8, 0, 0, 0, 0, 6, 0},
-                     {8, 0, 0, 0, 6, 0, 0, 0, 3},
-                     {4, 0, 0, 8, 0, 3, 0, 0, 1},
-                     {7, 0, 0, 0, 2, 0, 0, 0, 6},
-                     {0, 6, 0, 0, 0, 0, 2, 8, 0},
-                     {0, 0, 0, 4, 1, 9, 0, 0, 5},
-                     {0, 0, 0, 0, 8, 0, 0, 7, 9}}};
-}
-
 std::ostream &operator<<(std::ostream &stream, const Sudoku &sudoku) {
-    for (const auto& line : sudoku.field) {
-        for (const auto& cell : line) {
+    for (const auto &line : sudoku.field) {
+        for (const auto &cell : line) {
             stream << cell << "  ";
         }
         stream << std::endl;


### PR DESCRIPTION
cppcheck will now fail the build when it detects issues. As there was an
issue before, it had to be fixed before. The initialization had to be
moved from the cpp into the header file.