### PR TITLE
Informationen über die Coverage nur noch optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 before_script:
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake -DENABLE_COVERAGE=ON ..
   - cd ..
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,12 @@ set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --track-fds=yes"
 set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --trace-children=yes")
 set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --error-exitcode=1")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+if(ENABLE_COVERAGE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftest-coverage")
+endif()
 
 add_subdirectory(lib)
 add_subdirectory(app)

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -22,6 +22,7 @@ To do this you need to follow these steps.
       cmake ..
 
    to generate all files needed for the build.
+   When you want to collect coverage information you need to add ``-DENABLE_COVERAGE=ON`` to the command.
 3. Execute
 
    .. code-block:: sh


### PR DESCRIPTION
Standardmäßig werden keine Informationen über die Coverage gesammelt. Das Sammeln kann aktiviert werden, indem cmake mit der Option `-DENABLE_COVERAGE=ON` aufgerufen wird. Der automatische Build in Travis ermittelt weiterhin die Coverage.