### PR TITLE
Richtige Verwendung von X- und Y-Koordinaten

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -2,14 +2,14 @@
 
 #include "suso.h"
 
-int main () {
+int main() {
     Sudoku sudoku;
     std::cout << sudoku << std::endl;
 
 
     bool changed = true;
 
-    while(changed){
+    while (changed) {
         changed = sudoku.solveNakedSingles();
     }
 

--- a/lib/include/suso.h
+++ b/lib/include/suso.h
@@ -11,6 +11,22 @@ struct position {
 class Sudoku {
 private:
     std::array<std::array<int, 9>, 9> field;
+
+    /*!
+     * Returns if a given cell is not filled with a number.
+     * @param pos the position to check
+     * @return true if the cell is empty, false otherwise
+     */
+    bool isEmpty(position pos);
+
+    /*!
+     * Writes a number into the Sudoku field at a given position.
+     * No checks of the number are performed.
+     * @param pos where to insert the number
+     * @param num the number to insert
+     */
+    void insertNumber(position pos, int num);
+
 public:
     Sudoku() : field({{{5, 3, 0, 0, 7, 0, 0, 0, 0},
                               {6, 0, 0, 1, 9, 5, 0, 0, 0},

--- a/lib/src/suso.cpp
+++ b/lib/src/suso.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <vector>
 #include <set>
 
 #include "suso.h"
@@ -13,50 +14,53 @@ std::ostream &operator<<(std::ostream &stream, const Sudoku &sudoku) {
     return stream;
 }
 
+bool Sudoku::isEmpty(position pos) {
+    return field[pos.y][pos.x] == 0;
+}
+
+void Sudoku::insertNumber(position pos, int num) {
+    field[pos.y][pos.x] = num;
+}
+
 std::vector<int> Sudoku::validNumbers(position pos) {
-    std::set<int> posNumbers;
-    std::vector<int> res;
-
-    for (int i = 0; i < 9; i++) {
-        posNumbers.insert(i + 1);
-    }
-
-    for (int j = 0; j < 9; j++) {
-        posNumbers.erase(field[j][pos.y]);
-    }
-
-    for (int k = 0; k < 9; k++) {
-        posNumbers.erase(field[pos.x][k]);
-    }
-
+    std::set<int> res;
     int xBlock = (pos.x / 3) * 3;
     int yBlock = (pos.y / 3) * 3;
+    int x, y;
 
-    for (int l = 0; l < 3; l++) {
-        for (int m = 0; m < 3; m++) {
-            posNumbers.erase(field[xBlock + l][yBlock + m]);
+    for (int i = 1; i <= 9; i++) {
+        res.insert(i);
+    }
+
+    for (x = 0; x < 9; x++) {
+        res.erase(field[pos.y][x]);
+    }
+
+    for (y = 0; y < 9; y++) {
+        res.erase(field[y][pos.x]);
+    }
+
+    for (x = 0; x < 3; x++) {
+        for (y = 0; y < 3; y++) {
+            res.erase(field[yBlock + y][xBlock + x]);
         }
     }
 
-    for (std::set<int>::iterator it = posNumbers.begin(); it != posNumbers.end(); ++it) {
-        res.push_back(*it);
-    }
-    return res;
+    return std::vector<int>(res.begin(), res.end());
 }
 
 bool Sudoku::solveNakedSingles() {
     bool changed = false;
     struct position pos;
 
-    for (int k = 0; k < 9; k++) {
-        for (int l = 0; l < 9; l++) {
-            pos.x = k;
-            pos.y = l;
-            std::vector<int> res = validNumbers(pos);
-
-            if (res.size() == 1 && field[k][l] == 0) {
-                field[k][l] = res[0];
-                changed = true;
+    for (pos.x = 0; pos.x < 9; pos.x++) {
+        for (pos.y = 0; pos.y < 9; pos.y++) {
+            if (isEmpty(pos)) {
+                std::vector<int> res = validNumbers(pos);
+                if (res.size() == 1) {
+                    insertNumber(pos, res[0]);
+                    changed = true;
+                }
             }
         }
     }

--- a/lib/src/suso.cpp
+++ b/lib/src/suso.cpp
@@ -17,44 +17,44 @@ std::vector<int> Sudoku::validNumbers(position pos) {
     std::set<int> posNumbers;
     std::vector<int> res;
 
-    for(int i = 0; i<9; i++){
-        posNumbers.insert(i+1);
+    for (int i = 0; i < 9; i++) {
+        posNumbers.insert(i + 1);
     }
 
-    for(int j = 0; j< 9; j++){
+    for (int j = 0; j < 9; j++) {
         posNumbers.erase(field[j][pos.y]);
     }
 
-    for(int k = 0; k< 9; k++){
+    for (int k = 0; k < 9; k++) {
         posNumbers.erase(field[pos.x][k]);
     }
 
     int xBlock = (pos.x / 3) * 3;
-    int yBlock = (pos.y / 3) *3;
+    int yBlock = (pos.y / 3) * 3;
 
-    for (int l = 0; l < 3; l++){
-        for(int m = 0; m < 3; m++){
+    for (int l = 0; l < 3; l++) {
+        for (int m = 0; m < 3; m++) {
             posNumbers.erase(field[xBlock + l][yBlock + m]);
         }
     }
 
-    for (std::set<int>::iterator it=posNumbers.begin(); it!=posNumbers.end(); ++it){
+    for (std::set<int>::iterator it = posNumbers.begin(); it != posNumbers.end(); ++it) {
         res.push_back(*it);
     }
     return res;
 }
 
-bool Sudoku::solveNakedSingles(){
+bool Sudoku::solveNakedSingles() {
     bool changed = false;
     struct position pos;
 
-    for(int k = 0; k<9; k++){
-        for(int l = 0; l<9; l++){
+    for (int k = 0; k < 9; k++) {
+        for (int l = 0; l < 9; l++) {
             pos.x = k;
             pos.y = l;
             std::vector<int> res = validNumbers(pos);
 
-            if(res.size() == 1 && field[k][l] == 0) {
+            if (res.size() == 1 && field[k][l] == 0) {
                 field[k][l] = res[0];
                 changed = true;
             }

--- a/lib/test/CMakeLists.txt
+++ b/lib/test/CMakeLists.txt
@@ -1,17 +1,15 @@
 enable_testing()
-add_executable(sudoku_test sudokutest.cpp)
+add_executable(suso_test suso_test.cpp)
 
-target_include_directories(sudoku_test PRIVATE ${PROJECT_SOURCE_DIR}/lib/include)
-target_link_libraries(sudoku_test suso)
+add_dependencies(suso_test gtest)
 
-add_dependencies(sudoku_test gtest)
-target_include_directories(sudoku_test PRIVATE ${source_dir}/googletest/include
+target_include_directories(suso_test PRIVATE ${PROJECT_SOURCE_DIR}/lib/include)
+target_include_directories(suso_test PRIVATE ${source_dir}/googletest/include
         ${source_dir}/googlemock/include)
 
+target_link_libraries(suso_test suso)
+target_link_libraries(suso_test pthread)
+target_link_libraries(suso_test ${binary_dir}/googlemock/gtest/libgtest.a)
+target_link_libraries(suso_test ${binary_dir}/googlemock/gtest/libgtest_main.a)
 
-
-target_link_libraries(sudoku_test pthread)
-target_link_libraries(sudoku_test ${binary_dir}/googlemock/gtest/libgtest.a)
-target_link_libraries(sudoku_test ${binary_dir}/googlemock/gtest/libgtest_main.a)
-
-add_test(NAME sudoku-solverUnitTest COMMAND sudoku_test)
+add_test(NAME susoUnitTest COMMAND suso_test)

--- a/lib/test/suso_test.cpp
+++ b/lib/test/suso_test.cpp
@@ -1,5 +1,3 @@
-//
-// Created by Markus on 24.04.2018.
 #include "gtest/gtest.h"
 #include "suso.h"
 

--- a/lib/test/suso_test.cpp
+++ b/lib/test/suso_test.cpp
@@ -8,13 +8,13 @@ TEST(susoTest, validNumbersTest) {
     pos.y = 4;
     EXPECT_EQ(sudoku.validNumbers(pos).size(), 1);
     EXPECT_EQ(sudoku.validNumbers(pos)[0], 5);
-    pos.x = 2;
-    pos.y = 0;
+    pos.x = 0;
+    pos.y = 2;
     EXPECT_EQ(sudoku.validNumbers(pos).size(), 2);
     EXPECT_EQ(sudoku.validNumbers(pos)[0], 1);
     EXPECT_EQ(sudoku.validNumbers(pos)[1], 2);
-    pos.x = 0;
-    pos.y = 8;
+    pos.x = 8;
+    pos.y = 0;
     EXPECT_EQ(sudoku.validNumbers(pos).size(), 3);
     EXPECT_EQ(sudoku.validNumbers(pos)[0], 2);
     EXPECT_EQ(sudoku.validNumbers(pos)[1], 4);


### PR DESCRIPTION
Die Koordinaten müssen beim Zugriff auf das Feld vertauscht werden, um den erwarteten Koordinaten im dargestellten Spielfeld zu entsprechen. 

Zur Vermeidung solcher Fehler sollten wir in Zukunft so oft wie möglich Funktionen schreiben, die die Zugriffe für uns übernehmen. Damit wurde hier mit `isEmpty` und `insertNumber` begonnen. Die Funktionen werden auch schon in unseren Algorithmen eingesetzt. 

Außerdem wurden kleine Änderungen gemacht, die hauptsächlich Formatierung und Namen betreffen.